### PR TITLE
web font url을 http -> https로 변경해준다

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/src/assets/images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>프루떼-오늘도프룻해!</title>
-    <link href="http://fonts.googleapis.com/earlyaccess/notosanskr.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/earlyaccess/notosanskr.css" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 변경사항

- 웹 폰트 url이 http로 되어있어 배포 환경에서 응답받지 못하는 이슈를 해결합니다
