### PR TITLE
주문페이지에서 뒤로가기 했을 경우 해당 상품 상세 페이지가 보이지 않는 에러 해결

### DIFF
--- a/src/components/ProductDetail/ProductDetail.jsx
+++ b/src/components/ProductDetail/ProductDetail.jsx
@@ -98,6 +98,10 @@ const ProductDetail = () => {
     }
   };
 
+  // 주문페이지에서 뒤로가기 했을 경우, 상품 상세페이지 상태 관리
+  if (window.location.pathname === `/product-detail/${productId}` && isBuyClicked)
+    setIsBuyClicked(false);
+
   useEffect(() => {
     document.addEventListener('mousedown', handleClickOutside);
 


### PR DESCRIPTION
## 변경사항

- 윈도우 객체의 location 속성을 활용하여 path를 검사하여 상품 상세페이지의 상태를 관리 하여 위의 에러를 해결했습니다. 
